### PR TITLE
feat(auth): sécurisation du mot de passe (hashage + validation structurelle) — issue #14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "mongoose": "^9.1.5"
@@ -49,6 +50,20 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/body-parser": {
@@ -676,6 +691,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/MonLucCo/CEF_API-Express-MongoDB_Port-Plaisance-Russell_Test-version#readme",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "mongoose": "^9.1.5"


### PR DESCRIPTION
### Objectif de l’issue 14
Cette PR introduit la sécurisation du mot de passe en appliquant une séparation stricte des responsabilités entre :
- la couche métier (contrôleur) : hashage et logique d’authentification
- la couche donnée (modèle Mongoose) : cohérence structurelle et protection contre les erreurs humaines

### Modifications principales
- Hashage du mot de passe via bcrypt dans le contrôleur `register`
- Ajout d’une méthode d’instance `comparePassword` dans le modèle User pour factoriser la comparaison
- Ajout d’une validation structurelle garantissant que le champ `password` contient un hash bcrypt valide
- Gestion propre des erreurs de validation (`ValidationError`) dans le contrôleur
- Mise à jour de la JSDoc du modèle User (version 1.1.0)
- Mise à jour de la documentation technique (`docs-dev/architecture.md`, section 2.1.4)

### Tests réalisés (sans base MongoDB)
- POST /auth/register : hashage exécuté, aucune erreur interne
- POST /auth/register (mot de passe en clair) : ValidationError → 400 Bad Request
- POST /auth/login : appel de comparePassword, aucune erreur interne
- DELETE /auth/delete/:id : comportement identique à l’issue 13 (CastError attendu)

### Résultat
- Le modèle protège désormais la cohérence structurelle (aucun mot de passe en clair possible)
- Le contrôleur conserve la logique métier (hashage, comparaison, statuts HTTP)
- L’architecture reste claire, robuste, testable et évolutive
- Préparation directe pour l’issue 15 (JWT)

---

Fixes #14
