### PR TITLE
PR Issue-24 - ajout du contrôleur Catways et mise à jour des routes

### DIFF
--- a/docs-dev/architecture.md
+++ b/docs-dev/architecture.md
@@ -988,7 +988,32 @@ app.use('/catways', catwayRoutes);
 Cette étape garantit la cohérence architecturale et prépare l’ensemble de la Phase 4 (issues 23 à 30) qui implémente la logique métier Catways.
 L’application reste fonctionnellement identique à la Phase 3, mais la structure Express est désormais prête pour accueillir la logique métier Catways.
 
-Aucun test n'est prévu dans cette étape. Une validation de la cohérence du code est réalisée en lançant en local le serveur (CLI `npm run dev`).
+Aucun test automaisé n'est prévu dans cette étape. Une validation de la cohérence du code est réalisée en lançant en local le serveur (CLI `npm run dev`).
+
+---
+
+#### 2.3.2 Issue‑24 — Création du contrôleur Catways
+
+Cette issue introduit le fichier `catwayController.js` dans `src/controllers/`.  
+Il s’agit d’une étape structurelle : les six méthodes correspondant aux futures routes Catways sont créées, mais aucune logique métier n’est encore implémentée.
+
+Méthodes définies (placeholders) :
+
+- getAllCatways
+- getCatwayById
+- createCatway
+- updateCatway
+- patchCatway
+- deleteCatway
+
+Chaque méthode renvoie un statut HTTP **501 Not Implemented** (message : `<sujet> - Non implémenté (<issue>)`), conformément au découpage atomique de la Phase 4.
+
+Ce contrôleur sera progressivement complété dans les issues 25 à 30.
+
+Cette issue met également à jour le module `catwayRoutes.js` (version 0.1.0) afin de connecter les routes Catways au contrôleur Catways. Les six routes
+appellent désormais les méthodes placeholder du contrôleur, renvoyant un statut HTTP 501. Cette étape permet de valider le câblage Express avant l’implémentation progressive des fonctionnalités dans les issues 25 à 30.
+
+Aucun test automatisé n'est prévu dans cette étape. La vérification des routes est réalisée avec des requêtes Postman (serveur en exécution avec `npm run dev`).
 
 ---
 

--- a/src/controllers/catwayController.js
+++ b/src/controllers/catwayController.js
@@ -1,0 +1,59 @@
+/**
+ * @file catwayController.js
+ * @description Contrôleur Catways — version initiale (placeholder).
+ * 
+ * Cette version définit la structure des fonctions du contrôleur Catways,
+ * sans implémentation métier. Les méthodes seront complétées dans les
+ * issues 25 à 30.
+ * 
+ * @module controllers/catwayController
+ * @version 0.0.1
+ */
+
+/**
+ * GET /catways
+ * @description Récupère la liste des catways (non implémenté)
+ */
+exports.getAllCatways = (req, res) => {
+    res.status(501).json({ message: 'Récupère la liste des catways - Non implémenté (issue‑25)' });
+};
+
+/**
+ * GET /catways/:id
+ * @description Récupère un catway par ID (non implémenté)
+ */
+exports.getCatwayById = (req, res) => {
+    res.status(501).json({ message: 'Récupère un catway par ID - Non implémenté (issue‑26)' });
+};
+
+/**
+ * POST /catways
+ * @description Crée un nouveau catway (non implémenté)
+ */
+exports.createCatway = (req, res) => {
+    res.status(501).json({ message: 'Crée un nouveau catway - Non implémenté (issue‑27)' });
+};
+
+/**
+ * PUT /catways/:id
+ * @description Met à jour un catway (non implémenté)
+ */
+exports.updateCatway = (req, res) => {
+    res.status(501).json({ message: 'Mise à jour d’un catway - Non implémenté (issue‑28)' });
+};
+
+/**
+ * PATCH /catways/:id
+ * @description Actualise un catway (non implémenté)
+ */
+exports.patchCatway = (req, res) => {
+    res.status(501).json({ message: 'Actualise un catway - Non implémenté (issue‑29)' });
+};
+
+/**
+ * DELETE /catways/:id
+ * @description Supprime un catway (non implémenté)
+ */
+exports.deleteCatway = (req, res) => {
+    res.status(501).json({ message: 'Supprime un catway - Non implémenté (issue‑30)' });
+};

--- a/src/routes/catwayRoutes.js
+++ b/src/routes/catwayRoutes.js
@@ -1,18 +1,41 @@
 /**
- * @description Définition initiale du module de routes Catways.
+ * @description Module de routes Catways — version 0.1.0.
  * 
- * Cette version est un *placeholder* : les routes sont déclarées mais
- * aucune logique métier n’est encore implémentée. Le contrôleur Catways
- * sera ajouté dans l’issue‑24 et les méthodes seront implémentées dans
- * les issues 25 à 30.
+ * Cette version connecte les routes Catways au contrôleur Catways créé
+ * dans l’issue‑24. Chaque route appelle une méthode placeholder du
+ * contrôleur, renvoyant un statut HTTP 501 (Not Implemented) avec un message
+ * indiquant la fonctionnalité et l'issue concernée.
+ * 
+ * Les implémentations métier seront ajoutées progressivement dans les
+ * issues 25 à 30.
  * 
  * @module routes/catwayRoutes
  * @requires express
- * @version 0.0.1
+ * @requires controllers/catwayController
+ * @version 0.1.0
  */
-
 
 const express = require('express');
 const router = express.Router();
+
+const catwayController = require('../controllers/catwayController');
+
+// GET /catways — liste des catways
+router.get('/', catwayController.getAllCatways);
+
+// GET /catways/:id — détail d’un catway
+router.get('/:id', catwayController.getCatwayById);
+
+// POST /catways — création d’un catway
+router.post('/', catwayController.createCatway);
+
+// PUT /catways/:id — mise à jour complète
+router.put('/:id', catwayController.updateCatway);
+
+// PATCH /catways/:id — mise à jour partielle
+router.patch('/:id', catwayController.patchCatway);
+
+// DELETE /catways/:id — suppression
+router.delete('/:id', catwayController.deleteCatway);
 
 module.exports = router;


### PR DESCRIPTION
## Issue‑24 — Création du contrôleur Catways + mise à jour des routes

Cette PR introduit le contrôleur Catways (structure initiale) et met à jour le module de routes Catways pour appeler les méthodes placeholder.

### ✔ Contenu

- création du fichier `src/controllers/catwayController.js` (v0.0.1)
- ajout des 6 méthodes :
  - getAllCatways
  - getCatwayById
  - createCatway
  - updateCatway
  - patchCatway
  - deleteCatway
- mise à jour de `src/routes/catwayRoutes.js` (v0.1.0)
  - import du contrôleur
  - définition des 6 routes Catways
  - appels des méthodes placeholder (501)

### 📚 Documentation

- ajout de la section **2.3.2 — Issue‑24** dans `docs-dev/architecture.md`
- mention de la mise à jour des routes Catways

### 🔧 Prépare les issues suivantes

- issue‑25 : implémentation GET /catways
- issue‑26 : implémentation GET /catways/:id
- issue‑27 : POST /catways
- issue‑28 : PUT /catways/:id
- issue‑29 : PATCH /catways/:id
- issue‑30 : DELETE /catways/:id

PR prête pour revue et merge dans `dev`.
