### PR TITLE
PR Issue‑32 — Première version du contrôleur Reservations (v0.1.0)

### DIFF
--- a/docs-dev/architecture.md
+++ b/docs-dev/architecture.md
@@ -1565,6 +1565,16 @@ Cette architecture garantit une cohérence totale avec la Phase 4 et prépare la
 
 ---
 
+#### 2.4.2 Issue-32 Créations du contrôleur Reservation
+
+Cette issue introduit la structure initiale du contrôleur Reservations. Les quatre fonctions sont créées avec une JSDoc complète, versionnées en 0.1.0, et renvoient des réponses simulées.  
+
+Aucune logique métier n’est encore implémentée : les middlewares Reservation restent en placeholders.  
+
+Cette étape prépare l’implémentation progressive de la logique métier dans les issues 33 → 36.
+
+---
+
 ### 2.5 Phase 6 — Front-end minimal
 
 (sera complété avec les issues correspondantes)

--- a/src/controllers/reservationController.js
+++ b/src/controllers/reservationController.js
@@ -1,43 +1,116 @@
 /**
  * @file reservationController.js
- * @description Contrôleur des réservations associées aux catways.
- * Les fonctions sont des placeholders et seront implémentées dans les issues 33 → 36.
+ * @description Contrôleur des Reservations de l’API Port de Plaisance Russell.
+ *
+ * Version issue‑32 : implémentation minimale des fonctions du contrôleur,
+ * sans logique métier, sans accès base, sans middlewares.
+ *
+ * Les middlewares Catways et Reservations seront utilisés dans les issues 33 → 36.
+ * La logique métier complète sera introduite progressivement dans :
+ * - issue‑33 : GET /catways/:id/reservations
+ * - issue‑34 : GET /catways/:id/reservations/:idReservation
+ * - issue‑35 : POST /catways/:id/reservations
+ * - issue‑36 : DELETE /catways/:id/reservations/:idReservation
+ *
  * @module controllers/reservationController
- * @version 0.0.1
+ * @version 0.1.0
  */
 
 /**
- * Récupère la liste des réservations d’un catway.
+ * GET /catways/:id/reservations
  * @function getReservationsByCatway
- * @returns {void} 501 - Placeholder
+ * @description Récupère la liste des réservations associées à un catway.
+ *
+ * Version issue‑32 :
+ * - structure interne minimale
+ * - aucune logique métier
+ * - aucune interaction avec la base
+ *
+ * @param {Object} req - Objet Request Express
+ * @param {Object} res - Objet Response Express
+ * @returns {Object} 200 - Réponse JSON simulée
+ * 
+ * @version 0.1.0
+ * @todo Implémentation complète dans l’issue‑33
  */
 exports.getReservationsByCatway = (req, res) => {
-    res.status(501).json({ message: 'Not implemented' });
+    res.status(200).json({
+        message: 'GET reservations list — placeholder (issue‑32)',
+        catwayId: req.params.id
+    });
 };
 
 /**
- * Récupère une réservation spécifique d’un catway.
+ * GET /catways/:id/reservations/:idReservation
  * @function getReservationById
- * @returns {void} 501 - Placeholder
+ * @description Récupère le détail d’une réservation d’un catway.
+ *
+ * Version issue‑32 :
+ * - structure interne minimale
+ * - aucune logique métier
+ * - aucune interaction avec la base
+ *
+ * @param {Object} req - Objet Request Express
+ * @param {Object} res - Objet Response Express
+ * @returns {Object} 200 - Réponse JSON simulée
+ * 
+ * @version 0.1.0
+ * @todo Implémentation complète dans l’issue‑34
  */
 exports.getReservationById = (req, res) => {
-    res.status(501).json({ message: 'Not implemented' });
+    res.status(200).json({
+        message: 'GET reservation detail — placeholder (issue‑32)',
+        catwayId: req.params.id,
+        reservationId: req.params.idReservation
+    });
 };
 
 /**
- * Crée une réservation pour un catway.
+ * POST /catways/:id/reservations
  * @function createReservation
- * @returns {void} 501 - Placeholder
+ * @description Crée une réservation pour un catway.
+ *
+ * Version issue‑32 :
+ * - structure interne minimale
+ * - aucune logique métier
+ * - aucune interaction avec la base
+ *
+ * @param {Object} req - Objet Request Express
+ * @param {Object} res - Objet Response Express
+ * @returns {Object} 201 - Réponse JSON simulée
+ * 
+ * @version 0.1.0
+ * @todo Implémentation complète dans l’issue‑35
  */
 exports.createReservation = (req, res) => {
-    res.status(501).json({ message: 'Not implemented' });
+    res.status(201).json({
+        message: 'POST create reservation — placeholder (issue‑32)',
+        catwayId: req.params.id,
+        payload: req.body
+    });
 };
 
 /**
- * Supprime une réservation d’un catway.
+ * DELETE /catways/:id/reservations/:idReservation
  * @function deleteReservation
- * @returns {void} 501 - Placeholder
+ * @description Supprime une réservation d’un catway.
+ *
+ * Version issue‑32 :
+ * - structure interne minimale
+ * - aucune logique métier
+ * - aucune interaction avec la base
+ *
+ * @param {Object} req - Objet Request Express
+ * @param {Object} res - Objet Response Express
+ * @returns {Object} 200 - Réponse JSON simulée
+ * 
+ * @version 0.1.0
+ * @todo Implémentation complète dans l’issue‑36
  */
 exports.deleteReservation = (req, res) => {
-    res.status(501).json({ message: 'Not implemented' });
+    res.status(200).json({
+        message: 'DELETE reservation — placeholder (issue‑32)',
+        catwayId: req.params.id,
+        reservationId: req.params.idReservation
+    });
 };


### PR DESCRIPTION
### Description

Cette PR introduit la première version du contrôleur Reservations dans le cadre de la Phase‑5.  
Elle met en place les quatre fonctions du module `reservationController.js` sous forme de placeholders, sans logique métier, conformément aux spécifications de l’issue‑32.

### Contenu de la PR

#### 1) Nouveau contrôleur Reservations (`reservationController.js`, v0.1.0)

- création des quatre fonctions :
  - `getReservationsByCatway`
  - `getReservationById`
  - `createReservation`
  - `deleteReservation`
- aucune logique métier (réponses simulées)
- aucune interaction avec la base
- aucune validation ou résolution via les middlewares Reservations
- JSDoc complète, versionnée, avec TODO pour les issues 33 → 36

#### 2) Mise à jour documentaire

- **architecture.md**
  - ajout de la section **2.4.2 — Issue‑32 : Contrôleur Reservations (v0.1.0)**
  - description de la structure initiale du contrôleur et de son rôle dans la progression Phase‑5
- **decisions-techniques.md**
  - aucune modification (pas de nouvelle décision technique dans cette issue)

### Tests

Aucun test ajouté dans cette PR.  
Les tests unitaires et d’intégration seront introduits dans les issues suivantes :

- issue‑33 → GET liste  
- issue‑34 → GET détail  
- issue‑35 → POST  
- issue‑36 → DELETE  

### Validation

- structure du contrôleur conforme à l’architecture Phase‑4/Phase‑5  
- versioning JSDoc correct (v0.1.0)  
- documentation mise à jour  
- aucun impact sur les fonctionnalités existantes  

---
